### PR TITLE
fix duplicate answer in iife syntax qn

### DIFF
--- a/questions/explain-why-the-following-doesnt-work-as-an-iife-function-foo--what-needs-to-be-changed-to-properly-make-it-an-iife/en-US.mdx
+++ b/questions/explain-why-the-following-doesnt-work-as-an-iife-function-foo--what-needs-to-be-changed-to-properly-make-it-an-iife/en-US.mdx
@@ -28,6 +28,16 @@ To convert the function declaration into a function expression, you need to wrap
 (function foo() {})();
 ```
 
+### Alternative syntax
+
+You can also use an alternative syntax - immediate invocation:
+
+```javascript
+(function foo() {}());
+```
+
+Both of these syntaxes are valid and will correctly create an IIFE.
+
 ## Further reading
 
 - [MDN Web Docs: IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE)

--- a/questions/explain-why-the-following-doesnt-work-as-an-iife-function-foo--what-needs-to-be-changed-to-properly-make-it-an-iife/en-US.mdx
+++ b/questions/explain-why-the-following-doesnt-work-as-an-iife-function-foo--what-needs-to-be-changed-to-properly-make-it-an-iife/en-US.mdx
@@ -28,16 +28,6 @@ To convert the function declaration into a function expression, you need to wrap
 (function foo() {})();
 ```
 
-### Alternative syntax
-
-You can also use an alternative syntax by placing the parentheses after the function expression:
-
-```javascript
-(function foo() {})();
-```
-
-Both of these syntaxes are valid and will correctly create an IIFE.
-
 ## Further reading
 
 - [MDN Web Docs: IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE)

--- a/questions/explain-why-the-following-doesnt-work-as-an-iife-function-foo--what-needs-to-be-changed-to-properly-make-it-an-iife/en-US.mdx
+++ b/questions/explain-why-the-following-doesnt-work-as-an-iife-function-foo--what-needs-to-be-changed-to-properly-make-it-an-iife/en-US.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Explain why the following doesn't work as an IIFE: `function foo(){ }();`. What needs to be changed to properly make it an IIFE?"
+title: "Explain why the following doesn't work as an IIFE: `function foo(){}();`. What needs to be changed to properly make it an IIFE?"
 ---
 
 ## TL;DR
 
-The code `function foo(){ }();` doesn't work as an Immediately Invoked Function Expression (IIFE) because the JavaScript parser treats `function foo(){ }` as a function declaration, not an expression. To make it an IIFE, you need to wrap the function in parentheses to turn it into a function expression: `(function foo(){ })();`.
+The code `function foo(){}();` doesn't work as an Immediately Invoked Function Expression (IIFE) because the JavaScript parser treats `function foo(){}` as a function declaration, not an expression. To make it an IIFE, you need to wrap the function in parentheses to turn it into a function expression: `(function foo(){})();`.
 
 ---
 
@@ -12,7 +12,7 @@ The code `function foo(){ }();` doesn't work as an Immediately Invoked Function 
 
 ### Function declaration vs. function expression
 
-In JavaScript, a function declaration and a function expression are treated differently by the parser. The code `function foo(){ }` is interpreted as a function declaration. Function declarations are not immediately invoked; they are hoisted to the top of their scope and can be called later in the code.
+In JavaScript, a function declaration and a function expression are treated differently by the parser. The code `function foo(){}` is interpreted as a function declaration. Function declarations are not immediately invoked; they are hoisted to the top of their scope and can be called later in the code.
 
 ### Syntax error
 
@@ -22,18 +22,18 @@ When you try to immediately invoke a function declaration by adding `();` at the
 
 ### Wrapping in parentheses
 
-To convert the function declaration into a function expression, you need to wrap the entire function in parentheses. This tells the JavaScript parser to treat it as an expression. Here is the corrected code:
+To convert the function declaration into a function expression, you need to wrap the function declaration in parentheses. This tells the JavaScript parser to treat it as an expression. Here is the corrected code:
 
 ```javascript
-(function foo() {})();
+(function foo(){})();
 ```
 
 ### Alternative syntax
 
-You can also use an alternative syntax - immediate invocation:
+You can also use an alternative syntax by placing the parentheses around the original line:
 
 ```javascript
-(function foo() {}());
+(function foo(){}());
 ```
 
 Both of these syntaxes are valid and will correctly create an IIFE.


### PR DESCRIPTION
The suggested alternative syntax
```
(function foo() {})();
```
is the same as the previous one on line 28. 

So I suppose immediate invocation must be the one intended to be suggested.