### PR TITLE
Update en-US.mdx | Grammar error feel free to ignore

### DIFF
--- a/questions/explain-hoisting/en-US.mdx
+++ b/questions/explain-hoisting/en-US.mdx
@@ -4,7 +4,7 @@ title: Explain the concept of "hoisting" in JavaScript
 
 ## TL;DR
 
-- **Variable declarations (`var`)**: Declarations are hoisted, but not initializations. The value of the variable is `undefined` if accessed before initialization.
+- **Variable declarations (`var`)**: Declarations are hoisted, but not initialized. The value of the variable is `undefined` if accessed before initialization.
 - **Variable declarations (`let` and `const`)**: Declarations are hoisted, but not initialized. Accessing them results in `ReferenceError` until the actual declaration is encountered.
 - **Function expressions (`var`)**: Declarations are hoisted, but not initializations. The value of the variable is `undefined` if accessed before initialization.
 - **Function declarations (`function`)**: Both declaration and definition are fully hoisted.


### PR DESCRIPTION
Grammar error feel free to ignore

- **Variable declarations (`var`)**: Declarations are hoisted, but not initializations. The value of the variable is `undefined` if accessed before initialization.
- **Variable declarations (`var`)**: Declarations are hoisted, but not initialized. The value of the variable is `undefined` if accessed before initialization.