### PR TITLE
contents: fix tagged templates code example

### DIFF
--- a/questions/explain-the-concept-of-tagged-templates/en-US.mdx
+++ b/questions/explain-the-concept-of-tagged-templates/en-US.mdx
@@ -8,7 +8,7 @@ Tagged templates in JavaScript allow you to parse template literals with a funct
 
 ```js
 function tag(strings, ...values) {
-  return strings[0] + values[0] + strings[1] + values[1];
+  return strings[0] + values[0] + strings[1] + values[1] + strings[2];
 }
 
 const result = tag`Hello ${'world'}! How are ${'you'}?`;


### PR DESCRIPTION
The tagged template literal function fails to include the final static string segment ("?") from the strings array in its output. This happens because the function explicitly references only specific indices (strings[0] and strings[1]), omitting the last segment.

```
function tag(strings, ...values) {
  return strings[0] + values[0] + strings[1] + values[1];
}

const result = tag`Hello ${'world'}! How are ${'you'}?`;
console.log(result); // "Hello world! How are you?"
```
To get the desired log statement stated above the tag function should look like the following

```
function tag(strings, ...values) {
  return strings[0] + values[0] + strings[1] + values[1] + strings[2];
}
```

Fixes #9 