### PR TITLE
contents: fix behavior for `typeof` for undeclared variables

### DIFF
--- a/questions/whats-the-difference-between-a-variable-that-is-null-undefined-or-undeclared-how-would-you-go-about-checking-for-any-of-these-states/en-US.mdx
+++ b/questions/whats-the-difference-between-a-variable-that-is-null-undefined-or-undeclared-how-would-you-go-about-checking-for-any-of-these-states/en-US.mdx
@@ -8,14 +8,14 @@ subtitle: How would you go about checking for any of these states?"
 | Trait | `null` | `undefined` | Undeclared |
 | --- | --- | --- | --- |
 | Meaning | Explicitly set by the developer to indicate that a variable has no value | Variable has been declared but not assigned a value | Variable has not been declared at all |
-| Type | `object` | `undefined` | `undefined` |
+| Type (via `typeof` operator) | `'object'` | `'undefined'` | `'undefined'` |
 | Equality Comparison | `null == undefined` is `true` | `undefined == null` is `true` | Throws a `ReferenceError` |
 
 ---
 
 ## Undeclared
 
-**Undeclared** variables are created when you assign a value to an identifier that is not previously created using `var`, `let` or `const`. Undeclared variables will be defined globally, outside of the current scope. In strict mode, a `ReferenceError` will be thrown when you try to assign to an undeclared variable. Undeclared variables are bad just like how global variables are bad. Avoid them at all cost! To check for them, wrap its usage in a `try`/`catch` block.
+**Undeclared** variables are created when you assign a value to an identifier that is not previously created using `var`, `let` or `const`. Undeclared variables will be defined globally, outside of the current scope. In strict mode, a `ReferenceError` will be thrown when you try to assign to an undeclared variable. Undeclared variables are bad in the same way that global variables are bad. Avoid them at all cost! To check for them, wrap its usage in a `try`/`catch` block.
 
 ```js
 function foo() {
@@ -24,6 +24,12 @@ function foo() {
 
 foo();
 console.log(x); // 1
+```
+
+Using the `typeof` operator on undeclared variables will give `'undefined'`.
+
+```js
+console.log(typeof y === 'undefined'); // true
 ```
 
 ## `undefined`

--- a/questions/whats-the-difference-between-a-variable-that-is-null-undefined-or-undeclared-how-would-you-go-about-checking-for-any-of-these-states/en-US.mdx
+++ b/questions/whats-the-difference-between-a-variable-that-is-null-undefined-or-undeclared-how-would-you-go-about-checking-for-any-of-these-states/en-US.mdx
@@ -8,7 +8,7 @@ subtitle: How would you go about checking for any of these states?"
 | Trait | `null` | `undefined` | Undeclared |
 | --- | --- | --- | --- |
 | Meaning | Explicitly set by the developer to indicate that a variable has no value | Variable has been declared but not assigned a value | Variable has not been declared at all |
-| Type | `object` | `undefined` | Throws a `ReferenceError` |
+| Type | `object` | `undefined` | `undefined` |
 | Equality Comparison | `null == undefined` is `true` | `undefined == null` is `true` | Throws a `ReferenceError` |
 
 ---


### PR DESCRIPTION
The `typeof` operator returns `"undefined"` when used with an undeclared variable, 
`console.log(typeof z) // "undefined"`. 

However, directly accessing an undeclared variable (e.g., `console.log(z)`) throws a `ReferenceError`. This distinction is important for understanding JavaScript's behavior with undeclared variables and typeof.

Reference [Mdn](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof?#interaction_with_undeclared_and_uninitialized_variables)