### PR TITLE
fix: improve describe-event-bubbling

### DIFF
--- a/questions/describe-event-bubbling/en-US.mdx
+++ b/questions/describe-event-bubbling/en-US.mdx
@@ -151,7 +151,7 @@ productList.addEventListener('click', handleBuyClick);
 function handleBuyClick(event) {
   // Check if the clicked element is a button within the list
   if (event.target.tagName.toLowerCase() === 'button') {
-    console.log('Buy button clicked for item:', event.target.textContent);
+    console.log('Buy button clicked for item:', event.target.id);
   }
 }
 ```


### PR DESCRIPTION
Update the first event bubbling example to better match the previous code block. This helps focus the difference on the event bubbling, not this unrelated change.