### PR TITLE
Fix typo in recommendation for transpiler usage

### DIFF
--- a/questions/what-are-the-differences-between-variables-created-using-let-var-or-const/en-US.mdx
+++ b/questions/what-are-the-differences-between-variables-created-using-let-var-or-const/en-US.mdx
@@ -116,7 +116,7 @@ const bar = 'bar';
 - In modern JavaScript, it's generally recommended to use `const` by default for variables that don't need to be reassigned. This promotes immutability and prevents accidental changes.
 - Use `let` when you need to reassign a variable within its scope.
 - Avoid using `var` due to its potential for scoping issues and hoisting behavior.
-- If you need to target older browsers, write your code using `let`/`const`, and use a transpiler like Babel compile your code to older syntax.
+- If you need to target older browsers, write your code using `let`/`const`, and use a transpiler like Babel to compile your code to older syntax.
 
 ## Further reading
 


### PR DESCRIPTION
- Added the missing "to" in "use a transpiler like Babel _to_ compile your code".