### PR TITLE
Fix typos in "What advantage is there for using the JavaScript arrow …

### DIFF
--- a/questions/what-advantage-is-there-for-using-the-arrow-syntax-for-a-method-in-a-constructor/en-US.mdx
+++ b/questions/what-advantage-is-there-for-using-the-arrow-syntax-for-a-method-in-a-constructor/en-US.mdx
@@ -48,7 +48,7 @@ The main takeaway here is that `this` can be changed for a normal function, but 
 
 ## Arrow functions
 
-Arrow functions are introduced in ES2015 and it provides a concise way to write functions in Javascript. One of the key features of arrow function is that it lexically bind the `this` value, which means that it takes the `this` value from enclosing scope.
+Arrow functions were introduced in ES2015 and provide a concise way to write functions in Javascript. One of the key features of arrow function is that it lexically binds the `this` value, which means that it takes the `this` value from enclosing scope.
 
 ### Syntax
 


### PR DESCRIPTION
…syntax for a method in a constructor?"